### PR TITLE
Add Zooz ZSE29 Outdoor Motion Sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -2258,6 +2258,7 @@
 		<Product type="b111" id="1e1c" name="ZEN21 Switch V2.0" config="zooz/zen21.xml" />
 		<Product type="000c" id="0003" name="ZSE19 S2 Multisiren" config="zooz/zse19.xml" />
 		<Product type="a000" id="a004" name="ZEN20 V2.0 Power Strip" config="zooz/zen20v2.xml" />
+		<Product type="0001" id="0005" name="ZSE29 Outdoor Motion Sensor" config="zooz/zse29.xml" />
 	</Manufacturer>
 	<Manufacturer id="015d" name="Zooz (Willis Electric)">
 		<Product type="0651" id="f51c" name="ZEN20 Power Strip" config="zooz/zen20.xml" />

--- a/config/zooz/zse29.xml
+++ b/config/zooz/zse29.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Product xmlns='https://github.com/OpenZWave/open-zwave' Revision="1">
+    <!-- Zooz ZSE29 Outdoor Motion Sensor -->
+
+    <!-- Association Groups -->
+    <CommandClass id="133">
+        <Associations num_groups="2">
+            <Group index="1" max_associations="1" label="Lifeline"/>
+            <Group index="2" max_associations="4" label="PIR Control"/>
+        </Associations>
+    </CommandClass>
+</Product>


### PR DESCRIPTION
I contributed this to the upstream OpenZWave project so I thought I'd do it here too.

Adds support for the ZSE29 Outdoor Motion Sensor from Zooz. The device does not
use Z-Wave for configuration. There are manual knobs on the device to configure
the device.

Z-Wave Product Catalog page for reference:
https://products.z-wavealliance.org/products/3081

Tested this with an actual device using OpenZWave through Home Assistant.

Here's a reference to the PR on the OpenZWave Project:
https://github.com/OpenZWave/open-zwave/pull/1810