### PR TITLE
Check for Invalid HomeID or Controller Node ID's

### DIFF
--- a/cpp/src/Driver.cpp
+++ b/cpp/src/Driver.cpp
@@ -2642,6 +2642,15 @@ void Driver::HandleSerialAPIGetInitDataResponse
 {
 	int32 i;
 
+	if (m_homeId == 0 || m_Controller_nodeId == -1) {
+		Log::Write(LogLevel_Fatal, "Failed to get HomeID or Controller Node ID during Init Sequence");
+		Notification* notification = new Notification(Notification::Type_DriverFailed);
+		QueueNotification(notification);
+		NotifyWatchers();
+		m_driverThread->Stop();
+		return;
+	}
+	
 	if( !m_init )
 	{
 		// Mark the driver as ready (we have to do this first or


### PR DESCRIPTION
ModemManager on the Host is known to interfere with OZW, and cause problems when starting up. Users will often get messages about "Out of Frame Flow" in OZW_Log.txt. See https://github.com/home-assistant/home-assistant/issues/21165 for example. 

One of the more bizarre side effects of this, is that it causes issues with OZW initializing and a side effect is Node 255 (Broadcast) address will be added to all Associations on devices. This causes weird issues such as a switch triggering every Z-Wave Node in the network etc. 

This check will bail out if we receive a invalid HomeID or Controller Node ID when starting up and stop OZW from inadvertently adding this broadcast address to all node associations.