### PR TITLE
Initial backport of Fibaro FGWDEU-111 Walli Dimmer

### DIFF
--- a/config/fibaro/fgwd111.xml
+++ b/config/fibaro/fgwd111.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Product xmlns='http://code.google.com/p/open-zwave/'>
+    <!--
+    Fibaro FGWDEU-111 Wall Dimmer
+    https://products.z-wavealliance.org/products/3392
+    -->
+
+    <!-- Configuration Command Class - All Configuration Parameters should be entered into the section below -->
+    <CommandClass id="112">
+
+        <Value genre="config" index="1" label="Remember device state" max="1" min="0" size="1" type="byte" value="1">
+            <Help>This parameter determines how the device will react in the event of power supply failure (e.g. power outage). The parameter is not relevant for outputs set to pulse mode (parameter 150/151 set to 2).
+                0 - remains switched off after restoring power
+                1 - restores remembered state after restoring power
+            </Help>
+        </Value>
+
+        <Value genre="config" index="2" label="Overload safety switch" max="5000" min="0" size="4" type="int" value="3500">
+            <Help>This function allows to turn off the controlled device in case of exceeding the defined power. Controlled device can be turned back on via the button or sending a control frame.
+                0 - function disabled
+                10-5000 - (1.0-500.0W, step 0.1W) – power threshold
+            </Help>
+        </Value>
+
+        <Value genre="config" index="10" label="LED frame – power limit" max="5000" min="100" size="4" type="int" value="3500">
+            <Help>This parameter determines maximum active power. Exceeding it results in the LED frame flashing violet. Function is active only when parameter 11 is set to 8 or 9.
+                100-5000 - (10.0-500.0W, step 0.1W) – power threshold
+            </Help>
+        </Value>
+
+        <Value genre="config" index="11" label="LED frame – colour when ON" max="9" min="0" size="1" type="list" value="1">
+            <Help>This parameter defines the LED colour when thedevice is ON. When set to 8 or 9, LED frame colour will change depending on he measured power and parameter 10. Other colours are set permanently and do not depend on power consumption.
+            </Help>
+            <Item label="LED disabled" value="0"/>
+            <Item label="White" value="1"/>
+            <Item label="Red" value="2"/>
+            <Item label="Green" value="3"/>
+            <Item label="Blue" value="4"/>
+            <Item label="Yellow" value="5"/>
+            <Item label="Cyan" value="6"/>
+            <Item label="Magenta" value="7"/>
+            <Item label="Colour changes smoothly depending on measured power" value="8"/>
+            <Item label="Colour changes in steps depending on measured power" value="9"/>
+        </Value>
+
+        <Value genre="config" index="12" label="LED frame – colour when OFF" max="7" min="0" size="1" type="list" value="1">
+            <Help>This parameter defines the LED colour when the device is OFF.
+            </Help>
+            <Item label="LED disabled" value="0"/>
+            <Item label="White" value="1"/>
+            <Item label="Red" value="2"/>
+            <Item label="Green" value="3"/>
+            <Item label="Blue" value="4"/>
+            <Item label="Yellow" value="5"/>
+            <Item label="Cyan" value="6"/>
+            <Item label="Magenta" value="7"/>
+        </Value>
+
+        <Value genre="config" index="13" label="LED frame – brightness" max="102" min="0" size="1" type="byte" value="100">
+            <Help>This parameter allows to adjust the LED frame brightness.
+                0 - LED disabled
+                1-100 - (1-100% brightness)
+                101 - brightness directly proportional to measured power
+                102 - brightness inversely proportional asured powerto me
+            </Help>
+        </Value>
+
+        <Value genre="config" index="24" label="Buttons orientation" max="1" min="0" size="1" type="list" value="0">
+            <Help>This parameter allows reversing the operation of the buttons.
+            </Help>
+            <Item label="Default (1st button brightens, 2nd button dims)" value="0"/>
+            <Item label="Reversed (1st button dims, 2nd button brightens)" value="1"/>
+        </Value>
+
+        <Value genre="config" index="30" label="Alarm configuration - 1st slot" max="4" min="1" size="4" type="list" value="0">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
+            <Item label="[MSB] – Notification Type" value="1"/>
+            <Item label="Notification Value" value="2"/>
+            <Item label="Event/State Parameters" value="3"/>
+            <Item label="[LSB] – Action" value="4"/>
+        </Value>
+
+        <Value genre="config" index="31" label="Alarm configuration - 2nd slot" max="4" min="1" size="4" type="list" value="0">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
+            <Item label="[MSB] – Notification Type" value="1"/>
+            <Item label="Notification Value" value="2"/>
+            <Item label="Event/State Parameters" value="3"/>
+            <Item label="[LSB] – Action" value="4"/>
+        </Value>
+
+        <Value genre="config" index="32" label="Alarm configuration - 3rd slot" max="4" min="1" size="4" type="list" value="0">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
+            <Item label="[MSB] – Notification Type" value="1"/>
+            <Item label="Notification Value" value="2"/>
+            <Item label="Event/State Parameters" value="3"/>
+            <Item label="[LSB] – Action" value="4"/>
+        </Value>
+
+        <Value genre="config" index="33" label="Alarm configuration - 4th slot" max="4" min="1" size="4" type="list" value="0">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
+            <Item label="[MSB] – Notification Type" value="1"/>
+            <Item label="Notification Value" value="2"/>
+            <Item label="Event/State Parameters" value="3"/>
+            <Item label="[LSB] – Action" value="4"/>
+        </Value>
+
+        <Value genre="config" index="34" label="Alarm configuration - 5th slot" max="4" min="1" size="4" type="list" value="0">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
+            <Item label="[MSB] – Notification Type" value="1"/>
+            <Item label="Notification Value" value="2"/>
+            <Item label="Event/State Parameters" value="3"/>
+            <Item label="[LSB] – Action" value="4"/>
+        </Value>
+
+        <Value genre="config" index="35" label="Alarm configuration – duration" max="32400" min="0" size="2" type="short" value="600">
+            <Help>This parameter defines duration of alarm sequence.  When time set in this parameter elapses, alarm is cancelled, LED frame and relay restore normal operation, but do not recover state from before the alarm.
+                0 - Infinite
+                1-32400 - (1s-9h, 1s step) – Duration
+            </Help>
+        </Value>
+
+        <Value genre="config" index="40" label="First button – scenes sen" max="8" min="0" size="1" type="byte" value="0">
+            <Help>This parameter determines which actions result in sending scene IDs assigned to them. Values can be combined (e.g. 1+2=3 means that scenes for single and double click are sent). Enabling scenes for triple click disables entering the device in learn mode by triple clicking.
+                1 - Key pressed 1 time
+                2 - Key pressed 2 time
+                4 - Key pressed 3 time
+                8 - Key hold down and key released
+            </Help>
+        </Value>
+
+        <Value genre="config" index="41" label="Second button – scenes sent" max="8" min="0" size="1" type="byte" value="0">
+            <Help>This parameter determines which actions result in sending scene IDs assigned to them. Values can be combined (e.g. 1+2=3 means that scenes for single and double click are sent). Enabling scenes for triple click disables entering the device in learn mode by triple clicking.
+                1 - Key pressed 1 time
+                2 - Key pressed 2 time
+                4 - Key pressed 3 time
+                8 - Key hold down and key released
+            </Help>
+        </Value>
+
+        <Value genre="config" index="60" label="Power reports – include self-consumption" max="1" min="0" size="1" type="list" value="0">
+            <Help>This parameter determines whether the power measurements should include power consumed by the device itself.
+            </Help>
+            <Item label="Self-consumption not included" value="0"/>
+            <Item label="Self-consumption included" value="1"/>
+        </Value>
+
+        <Value genre="config" index="61" label="Power reports – on change" max="500" min="0" size="2" type="short" value="15">
+            <Help>This parameter defines minimal change (from the last reported) in measured power that results in sending new report. For loads under 50W the parameter is irrelevant, report are sent every 5W change.
+                0 - Reporting on change disabled
+                1-500 - (1-500%, 1% step) – Minimal change
+            </Help>
+        </Value>
+
+        <Value genre="config" index="62" label="Power reports – periodic" max="32400" min="0" size="2" type="short" value="3600">
+            <Help>This parameter defines reporting interval for measured power. Periodic reports are independent from changes in value (parameter 61).
+                0 - periodic reports disabled
+                30-32400 - (30s-9h, 1s step) – time interval
+            </Help>
+        </Value>
+
+        <Value genre="config" index="65" label="Energy reports – on change" max="500" min="0" size="2" type="short" value="10">
+            <Help>This parameter defines minimal change (from the last reported) in measured energy that results in sending new report.
+                0 - reporting on change disabled
+                1-500 - (0.01-5kWh, 0.01kWh step) – minimal change
+            </Help>
+        </Value>
+
+        <Value genre="config" index="66" label="Energy reports – periodic" max="32400" min="0" size="2" type="short" value="3600">
+            <Help>This parameter defines reporting interval for measured energy. Periodic reports are independent from changes in value (parameter 65).
+                0 - periodic reports disabled
+                30-32400 - (30s-9h, 1s step) – time interval
+            </Help>
+        </Value>
+
+        <Value genre="config" index="150" label="Minimum brightness level" max="98" min="1" size="1" type="byte" value="1">
+            <Help>This parameter is set automatically during the calibration process, but can be changed manually after the calibration.
+                1-98 - (1-98%, 1% step) – level of brightness
+            </Help>
+        </Value>
+
+        <Value genre="config" index="151" label="Maximum brightness level" max="99" min="2" size="1" type="byte" value="99">
+            <Help>This parameter is set automatically during the calibration process, but can be changed manually after the calibration.
+                2-99 - (2-99%, 1% step) – level of brightness
+            </Help>
+        </Value>
+
+        <Value genre="config" index="152" label="Incandescence level of dimmable compact fluorescent lamps" max="99" min="1" size="1" type="byte" value="1">
+            <Help>The virtual value set as a percentage level between parameters MIN (1%) and MAX. (99%). The device will set to this value after the first switch on. It is required for warming up and switching dimmable compact fluorescent lamps and certain types of light sources.
+                1-99 - (1-98%, 1% step) – level of brightness
+            </Help>
+        </Value>
+
+        <Value genre="config" index="153" label="Incandescence time of dimmable compact fluorescent lamps" max="255" min="0" size="2" type="short" value="0">
+            <Help>This parameter determines the time required for switching compact fluorescent lamps and certain types of light sources. Setting this parameter to 0 will disable the incandescence functionality.
+                0-255 - (0-25.5s, 0.1s step) – incandescence time
+            </Help>
+        </Value>
+
+        <Value genre="config" index="154" label="Automatic control – dimming step size" max="99" min="1" size="1" type="byte" value="1">
+            <Help>This parameter defines the percentage value of dimming step during the automatic control.
+                0-99 - (1-99%, 1% step) – dimming step
+            </Help>
+        </Value>
+
+        <Value genre="config" index="155" label="Automatic control – time of dimming step" max="255" min="0" size="2" type="short" value="1">
+            <Help>This parameter defines the time of performing a single dimming step set in parameter 154 during the automatic control.
+                0-255 - This parameter defines the time of performing a single dimming step set in parameter 154 during the automatic control.
+            </Help>
+        </Value>
+
+        <Value genre="config" index="156" label="Manual control – dimming step size" max="99" min="1" size="1" type="byte" value="1">
+            <Help>This parameter defines the percentage value of the dimming step during the manual control.
+                1-99 - (1-99%, 1% step) – dimming step
+            </Help>
+        </Value>
+
+        <Value genre="config" index="157" label="Manual control – time of dimming step" max="255" min="0" size="2" type="short" value="5">
+            <Help>This parameter defines the time of performing a single dimming step set in parameter 156 during the manual control.
+                0-255 - (0-2.55s, 10ms step)
+            </Help>
+        </Value>
+
+        <Value genre="config" index="158" label="Auto-off functionality" max="32767" min="0" size="2" type="short" value="0">
+            <Help>This parameter allows to automatically switch off the device after a specified time from switching the light source on. It may be useful when the device is installed in the stairway.
+                0 - auto-off disabled
+                1-32767 - (1s-9.1h, 1s step) – auto-off time
+            </Help>
+        </Value>
+
+        <Value genre="config" index="159" label="Force auto-calibration" max="2" min="0" size="1" type="list" value="0">
+            <Help>Changing value of this parameter will force the calibration process. During the calibration parameter is set to 1 or 2 and switched to 0 upon completion.
+            </Help>
+            <Item label="Readout" value="0"/>
+            <Item label="Force auto-calibration without FIBARO Bypass 2" value="1"/>
+            <Item label="Force auto-calibration with FIBARO Bypass 2" value="2"/>
+        </Value>
+
+        <Value genre="config" index="160" label="Auto-calibration status (read-only parameter)" max="1" min="0" size="1" type="list" value="0">
+            <Help>This parameter determines operating mode of the device (automatic/manual settings).
+            </Help>
+            <Item label="Calibration procedure not performed or the device operates on manual settings" value="0"/>
+            <Item label="The device operates on auto-calibration settings" value="1"/>
+        </Value>
+
+        <Value genre="config" index="161" label="Burnt out bulb detection" max="99" min="0" size="2" type="short" value="0">
+            <Help>This parameter defines percentage power variation (compared to power consumption measured during the calibration) to be interpreted as load error/burnt out bulb.
+                0 - function disabled
+                1-99 - (1-99%, 1% step) – power variation
+            </Help>
+        </Value>
+
+        <Value genre="config" index="162" label="Time delay of a burnt out bulb and overload detection" max="255" min="0" size="2" type="short" value="5">
+            <Help>This parameter defines detection delay for the burnt out bulb (parameter 161) and overload (parameter 2).
+                0 - detection of a burnt out bulb disabled
+                1-255 - (1-255s, 1s step) – time delay
+            </Help>
+        </Value>
+
+        <Value genre="config" index="163" label="First button – Switch ON value sent to 2nd and 3rd association groups" max="255" min="0" size="2" type="short" value="255">
+            <Help>This parameter defines value sent with Switch OFF command to devices associated in 2nd and 3rd association group.
+                0-99 - value sent
+                254 - send value equal to the current level
+                255 - value sent
+            </Help>
+        </Value>
+
+        <Value genre="config" index="164" label="Second button – Switch OFF value sent to 2nd and 3rd association groups" max="255" min="0" size="2" type="short" value="0">
+            <Help>This parameter defines value sent with Switch ON command to devices associated in 2nd and 3rd association group.
+                0-99 - value sent
+                254 - send value equal to the current level
+                255 - value sent
+            </Help>
+        </Value>
+
+        <Value genre="config" index="165" label="Double click – set level" max="99" min="0" size="1" type="byte" value="99">
+            <Help>This parameter defines brightness level set after double-clicking any of the buttons. The same value is also sent to devices associated with 2nd and 3rd association group.
+                0-99 - (0-99%, 1% step) – set level
+            </Help>
+        </Value>
+
+        <Value genre="config" index="170" label="Load control mode" max="2" min="0" size="1" type="list" value="2">
+            <Help>This parameter allows to set the desired load control mode. Auto-calibration sets value of this parameter to 2 (control mode recognized during auto-calibration), but the installer may force control mode using this parameter. After changing parameter value, turn the load OFF and ON to change control mode.
+            </Help>
+            <Item label="Forced leading edge" value="0"/>
+            <Item label="Forced trailing edge" value="1"/>
+            <Item label="Control mode selected automatically (based on auto-calibration)" value="2"/>
+        </Value>
+
+        <Value genre="config" index="171" label="Load control mode recognized during auto-calibration (read only)" max="1" min="0" size="1" type="list" value="0">
+            <Help>This parameter allows to read load control mode that was set during auto-calibration.
+            </Help>
+            <Item label="Leading edge" value="0"/>
+            <Item label="Trailing edge" value="1"/>
+        </Value>
+
+        <Value genre="config" index="172" label="ON/OFF mode" max="2" min="0" size="1" type="list" value="2">
+            <Help>This mode is necessary while connecting non-dimmable light sources. Setting this parameter to 1 automatically ignores brightening/dimming time settings. Forced auto-calibration will set this parameter’s value to 2.
+            </Help>
+            <Item label="ON/OFF mode disabled (dimming is possible)" value="0"/>
+            <Item label="ON/OFF mode enabled (dimming is not possible)" value="1"/>
+            <Item label="Mode selected automatically" value="2"/>
+        </Value>
+
+        <Value genre="config" index="173" label="Dimmability of the load (read only)" max="1" min="0" size="1" type="list" value="0">
+            <Help>This parameter allows to read if the load detected during calibration procedure is dimmable.
+            </Help>
+            <Item label="Load recognized as dimmable" value="0"/>
+            <Item label="Load recognized as non-dimmable" value="1"/>
+        </Value>
+
+        <Value genre="config" index="174" label="Soft-start functionality" max="2" min="0" size="1" type="list" value="1">
+            <Help>This parameter allows to set time required to warm up the filament of halogen bulb.
+            </Help>
+            <Item label="No soft-start" value="0"/>
+            <Item label="Short soft-start (0.1s)" value="1"/>
+            <Item label="Long soft-start (0.5s)" value="2"/>
+        </Value>
+
+        <Value genre="config" index="175" label="Auto-calibration after power on" max="4" min="0" size="1" type="list" value="1">
+            <Help>This parameter determines the trigger of auto-calibration procedure, e.g. power on, load error, etc.
+            </Help>
+            <Item label="No auto-calibration after power on" value="0"/>
+            <Item label="Auto-calibration after each power on" value="2"/>
+            <Item label="Auto-calibration after each LOAD ERROR (no load, load failure, burnt out bulb), if parameter 176 is set to 1 also after SURGE (output overvoltage) and OVERCURRENT (output overcurrent)" value="3"/>
+            <Item label="Auto-calibration after each power on or after each LOAD ERROR (no load, load failure, burnt out bulb), if parameter 176 is set to 1 also after SURGE (output overvoltage) and OVERCURRENT (output overcurrent)" value="4"/>
+        </Value>
+
+        <Value genre="config" index="176" label="Behaviour after OVERCURRENT or SURGE" max="1" min="0" size="1" type="list" value="1">
+            <Help>Error occurrences related to surge or overcurrent results in turning off the output to prevent possible malfunction. By default the device performs three attempts to turn on the load (useful in case of temporary, short failures of the power supply).
+            </Help>
+            <Item label="Device permanently disabled until re-enabling by command or external switch" value="0"/>
+            <Item label="Three attempts to turn on the load" value="1"/>
+        </Value>
+
+        <Value genre="config" index="177" label="Brightness level correction for flickering loads" max="255" min="0" size="2" type="short" value="255">
+            <Help>Correction reduces spontaneous flickering of some capacitive loads (e.g. dimmable LEDs) at certain brightness levels in 2-wire installation.
+                In countries using ripple-control, correction may cause changes in brightness. In this case it is necessary to disable correction or adjust the time of correction for flickering loads.
+                0 - automatic correction disabled
+                1-254 - (1-254s, 1s step) – duration of correction
+                255 - automatic correction always enabled
+            </Help>
+        </Value>
+
+        <Value genre="config" index="178" label="Method of calculating the active power" max="2" min="0" size="1" type="list" value="0">
+            <Help>This parameter defines how to calculate active power. It is useful in a case of 2-wire connection with light sources other than resistive.
+            </Help>
+            <Item label="Measurement based on the standard algorithm" value="0"/>
+            <Item label="Approximation based on the calibration data" value="1"/>
+            <Item label="Approximation based on the control angle" value="2"/>
+        </Value>
+
+        <Value genre="config" index="179" label="Approximated power at the maximum brightness level" max="500" min="0" size="2" type="short" value="0">
+            <Help>This parameter determines the approximate value of the power that will be reported by the device at its maximum brightness level.
+                0-500 - (0-500W, 1W step) – power consumed by the load at the maximum brightness level.
+            </Help>
+        </Value>
+
+    </CommandClass>
+    <!-- The Association Group Information -->
+    <CommandClass id="133">
+        <Associations num_groups="3">
+            <Group index="1" label="LifeLine" max_associations="1"/>
+            <Group index="2" label="On/Off" max_associations="5"/>
+            <Group index="3" label="Dimmer" max_associations="5"/>
+        </Associations>
+    </CommandClass>
+
+</Product>

--- a/config/fibaro/fgwd111.xml
+++ b/config/fibaro/fgwd111.xml
@@ -73,44 +73,35 @@
             <Item label="Reversed (1st button dims, 2nd button brightens)" value="1"/>
         </Value>
 
-        <Value genre="config" index="30" label="Alarm configuration - 1st slot" max="4" min="1" size="4" type="list" value="0">
-            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
-            <Item label="[MSB] – Notification Type" value="1"/>
-            <Item label="Notification Value" value="2"/>
-            <Item label="Event/State Parameters" value="3"/>
-            <Item label="[LSB] – Action" value="4"/>
-        </Value>
-
-        <Value genre="config" index="31" label="Alarm configuration - 2nd slot" max="4" min="1" size="4" type="list" value="0">
-            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
-            <Item label="[MSB] – Notification Type" value="1"/>
-            <Item label="Notification Value" value="2"/>
-            <Item label="Event/State Parameters" value="3"/>
-            <Item label="[LSB] – Action" value="4"/>
-        </Value>
-
-        <Value genre="config" index="32" label="Alarm configuration - 3rd slot" max="4" min="1" size="4" type="list" value="0">
-            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
-            <Item label="[MSB] – Notification Type" value="1"/>
-            <Item label="Notification Value" value="2"/>
-            <Item label="Event/State Parameters" value="3"/>
-            <Item label="[LSB] – Action" value="4"/>
-        </Value>
-
-        <Value genre="config" index="33" label="Alarm configuration - 4th slot" max="4" min="1" size="4" type="list" value="0">
-            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
-            <Item label="[MSB] – Notification Type" value="1"/>
-            <Item label="Notification Value" value="2"/>
-            <Item label="Event/State Parameters" value="3"/>
-            <Item label="[LSB] – Action" value="4"/>
-        </Value>
-
-        <Value genre="config" index="34" label="Alarm configuration - 5th slot" max="4" min="1" size="4" type="list" value="0">
-            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.</Help>
-            <Item label="[MSB] – Notification Type" value="1"/>
-            <Item label="Notification Value" value="2"/>
-            <Item label="Event/State Parameters" value="3"/>
-            <Item label="[LSB] – Action" value="4"/>
+        <Value type="int" index="30" genre="config" label="Alarm configuration - 1st slot" value="0" min="0" max="4294967295">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.
+1B:  [MSB] Notification Type, 2B:  Notification Status, 3B: Event/State Parameters, 4B: [LSB] action
+0xX0: no action on output, 0xX1: turn ON, 0xX2: turn OFF, 0xX3: turn ON/OFF continuously, 0x0X: no action on LED frame, 0x1X: LED frame blinks red, 0x2X: LED frame blinks green, 0x4X: LED frame blinks blue, 0x8X: disable LED frame, 0xFX: LED frame LAPD signal (red-white-blue)
+            </Help>
+            </Value>
+        <Value type="int" index="31" genre="config" label="Alarm configuration - 2nd slot" value="0" min="0" max="4294967295">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.
+1B:  [MSB] Notification Type, 2B:  Notification Status, 3B: Event/State Parameters, 4B: [LSB] action
+0xX0: no action on output, 0xX1: turn ON, 0xX2: turn OFF, 0xX3: turn ON/OFF continuously, 0x0X: no action on LED frame, 0x1X: LED frame blinks red, 0x2X: LED frame blinks green, 0x4X: LED frame blinks blue, 0x8X: disable LED frame, 0xFX: LED frame LAPD signal (red-white-blue)
+            </Help>
+            </Value>
+        <Value type="int" index="32" genre="config" label="Alarm configuration - 3rd slot" value="0" min="0" max="4294967295">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.
+1B:  [MSB] Notification Type, 2B:  Notification Status, 3B: Event/State Parameters, 4B: [LSB] action
+0xX0: no action on output, 0xX1: turn ON, 0xX2: turn OFF, 0xX3: turn ON/OFF continuously, 0x0X: no action on LED frame, 0x1X: LED frame blinks red, 0x2X: LED frame blinks green, 0x4X: LED frame blinks blue, 0x8X: disable LED frame, 0xFX: LED frame LAPD signal (red-white-blue)
+            </Help>
+            </Value>
+        <Value type="int" index="33" genre="config" label="Alarm configuration - 4th slot" value="0" min="0" max="4294967295">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.
+1B:  [MSB] Notification Type, 2B:  Notification Status, 3B: Event/State Parameters, 4B: [LSB] action
+0xX0: no action on output, 0xX1: turn ON, 0xX2: turn OFF, 0xX3: turn ON/OFF continuously, 0x0X: no action on LED frame, 0x1X: LED frame blinks red, 0x2X: LED frame blinks green, 0x4X: LED frame blinks blue, 0x8X: disable LED frame, 0xFX: LED frame LAPD signal (red-white-blue)
+            </Help>
+            </Value>
+        <Value type="int" index="34" genre="config" label="Alarm configuration - 5th slot" value="0" min="0" max="4294967295">
+            <Help>This parameter determines to which alarm frames and how the device should react. The parameters consist of 4 bytes, three most significant bytes are set according to the official Z-Wave protocol specification.
+1B:  [MSB] Notification Type, 2B:  Notification Status, 3B: Event/State Parameters, 4B: [LSB] action
+0xX0: no action on output, 0xX1: turn ON, 0xX2: turn OFF, 0xX3: turn ON/OFF continuously, 0x0X: no action on LED frame, 0x1X: LED frame blinks red, 0x2X: LED frame blinks green, 0x4X: LED frame blinks blue, 0x8X: disable LED frame, 0xFX: LED frame LAPD signal (red-white-blue)
+            </Help>
         </Value>
 
         <Value genre="config" index="35" label="Alarm configuration – duration" max="32400" min="0" size="2" type="short" value="600">
@@ -357,6 +348,7 @@
         </Value>
 
     </CommandClass>
+
     <!-- The Association Group Information -->
     <CommandClass id="133">
         <Associations num_groups="3">
@@ -365,5 +357,4 @@
             <Group index="3" label="Dimmer" max_associations="5"/>
         </Associations>
     </CommandClass>
-
 </Product>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -817,6 +817,7 @@
 		<Product type="1301" id="1000" name="FGT001 Heat Controller" config="fibaro/fgt001.xml"/>
 		<Product type="1701" id="2000" name="FGWPG111 US Wall Plug" config="fibaro/fgwpg111.xml"/>
 		<Product type="1801" id="1000" name="FGWPG111 UK Wall Plug" config="fibaro/fgwpg111.xml"/>
+		<Product type="1C01" id="1000" name="FGWDEU-111 Walli Dimmer" config="fibaro/fgwd111.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0295" name="fifthplay nv">
 	</Manufacturer>


### PR DESCRIPTION
Based on: https://community.home-assistant.io/t/fibaro-walli-integration/127332

Hi!

This PR contains a backport of the existing Fibaro Walli Dimmer definition of the original Open-Zwave project. I tested this on my Home Assistant installation, and it seems to recognize the device. It does however not yet recognize any actions (See screenshot: only sensors, no switches or lights). What that's about I'm not sure, but I hope to find that out along the way in this PR.

One other note: the XML provided in the community thread deviates in one minor way from the Open-Zwave project definitions - those have to do with the Alarm settings (dropdown vs input). I might synchronize that as well.

Integration screenshot:
![image](https://user-images.githubusercontent.com/705382/70448336-1ea98a00-1a98-11ea-821a-4f7aa30f711e.png)

If someone could point the way as to why I don't see a switch entity I would be massively grateful.

Regards,