### PR TITLE
Add Fibaro flood sensor

### DIFF
--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -798,6 +798,7 @@
 		<Product type="0b01" id="1002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0b01" id="1003" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0b01" id="2002" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
+		<Product type="0b01" id="2003" name="FGFS101 Zwave+ Flood Sensor" config="fibaro/fgfs101zw5.xml" />
 		<Product type="0900" id="1000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml" />
 		<Product type="0900" id="2000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>
 		<Product type="0900" id="3000" name="FGRGBWM441 RGBW Controller" config="fibaro/fgrgbwm441.xml"/>


### PR DESCRIPTION
Came across a Fibaro flood sensor variant with type/id=0b01/2003.

Change was already accepted upstream: https://github.com/OpenZWave/open-zwave/pull/2050