### PR TITLE
Add Aeotec Radiator Thermostat (zwa021)

### DIFF
--- a/config/aeotec/zwa021.xml
+++ b/config/aeotec/zwa021.xml
@@ -104,4 +104,3 @@ Product website: https://aeotec.com/z-wave-home-automation/thermostat-radiator-v
         </Value>
     </CommandClass>
 </Product>
-

--- a/config/aeotec/zwa021.xml
+++ b/config/aeotec/zwa021.xml
@@ -3,7 +3,7 @@
 Aeotec Radiator Thermostat
 Product website: https://aeotec.com/z-wave-home-automation/thermostat-radiator-valve-trv/
 -->
-<Product xmlns="https://github.com/OpenZWave/open-zwave">
+<Product xmlns='https://github.com/OpenZWave/open-zwave'>
     <!-- Multilevel switch for setting valve opening -->
     <CommandClass id="38">
         <Value type="byte" genre="user" index="0" label="Valve Opening" units="%" min="0" max="100" value="0" />
@@ -16,7 +16,7 @@ Product website: https://aeotec.com/z-wave-home-automation/thermostat-radiator-v
                 Off: No heating, only frost protection.
                 Heat: Room temperature will be kept at the configured setpoint.
                 Heat Eco: Energy save heating mode. Room temperature will be lowered to the configured eco setpoint in order to save energy.
-                Full Power: Full power heating. This mode is left automatically after 5 minutes.
+                Boost: Full power heating. This mode is left automatically after 5 minutes.
                 Manufacturer Specific: Direct valve control mode. The valve opening percentage can be controlled using the switch multilevel command class.
             </Help>
             <Item label="Off" value="0"/>
@@ -38,10 +38,6 @@ Product website: https://aeotec.com/z-wave-home-automation/thermostat-radiator-v
         <Instance index="1"/>
         <Value genre="user" index="1" instance="1" label="Heat" max="28" min="8" read_only="false" type="decimal" units="°C" value="20" write_only="false"/>
         <Value genre="user" index="11" instance="1" label="Heat Eco" max="28" min="8" read_only="false" type="decimal" units="°C" value="16" write_only="false"/>
-        <Compatibility>
-            <Base>0</Base>
-            <AltTypeInterpretation>false</AltTypeInterpretation>
-        </Compatibility>
     </CommandClass>
     <!-- Configuration Parameters -->
     <CommandClass id="112">

--- a/config/aeotec/zwa021.xml
+++ b/config/aeotec/zwa021.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Aeotec Radiator Thermostat
+Product website: https://aeotec.com/z-wave-home-automation/thermostat-radiator-valve-trv/
+-->
+<Product xmlns="https://github.com/OpenZWave/open-zwave">
+    <!-- Multilevel switch for setting valve opening -->
+    <CommandClass id="38">
+        <Value type="byte" genre="user" index="0" label="Valve Opening" units="%" min="0" max="100" value="0" />
+    </CommandClass>
+    <!-- Thermostat mode -->
+    <CommandClass id="64">
+        <Instance index="1"/>
+        <Value genre="user" index="0" instance="1" label="Mode" type="list">
+            <Help>
+                Off: No heating, only frost protection.
+                Heat: Room temperature will be kept at the configured setpoint.
+                Heat Eco: Energy save heating mode. Room temperature will be lowered to the configured eco setpoint in order to save energy.
+                Full Power: Full power heating. This mode is left automatically after 5 minutes.
+                Manufacturer Specific: Direct valve control mode. The valve opening percentage can be controlled using the switch multilevel command class.
+            </Help>
+            <Item label="Off" value="0"/>
+            <Item label="Heat" value="1"/>
+            <Item label="Heat Eco" value="11"/>
+            <Item label="Boost" value="15"/>
+            <Item label="Manufacturer Specific" value="31"/>
+        </Value>
+        <SupportedModes>
+            <Mode index="0" label="Off"/>
+            <Mode index="1" label="Heat"/>
+            <Mode index="11" label="Heat Eco"/>
+            <Mode index="15" label="Boost"/>
+            <Mode index="31" label="Manufacturer Specific"/>
+        </SupportedModes>
+    </CommandClass>
+    <!-- Setpoints -->
+    <CommandClass id="67" base="0" typeInterpretation="A">
+        <Instance index="1"/>
+        <Value genre="user" index="1" instance="1" label="Heat" max="28" min="8" read_only="false" type="decimal" units="°C" value="20" write_only="false"/>
+        <Value genre="user" index="11" instance="1" label="Heat Eco" max="28" min="8" read_only="false" type="decimal" units="°C" value="16" write_only="false"/>
+        <Compatibility>
+            <Base>0</Base>
+            <AltTypeInterpretation>false</AltTypeInterpretation>
+        </Compatibility>
+    </CommandClass>
+    <!-- Configuration Parameters -->
+    <CommandClass id="112">
+        <Instance index="1"/>
+        <Value genre="config" index="1" instance="1" label="LCD Invert" max="1" min="0" size="1" type="list" value="0">
+            <Help>
+                Allows rotating the LCD contents by 180 degrees.
+                Default: Normal
+            </Help>
+            <Item label="Normal" value="0"/>
+            <Item label="Upside Down" value="1"/>
+        </Value>
+        <Value genre="config" index="2" instance="1" label="LCD Timeout" max="30" min="0" type="byte" units="sec" value="0">
+            <Help>
+                0: No Timeout, LCD always on.
+                5-30: Timeout after 5-30s.
+                Default: 0 (LCD always on)
+            </Help>
+        </Value>
+        <Value genre="config" index="3" instance="1" label="Backlight" max="1" min="0" size="1" type="list" units="" value="1">
+            <Help>
+                Default: Backlight enabled
+            </Help>
+            <Item label="Backlight disabled" value="0"/>
+            <Item label="Backlight enabled" value="1"/>
+        </Value>
+        <Value genre="config" index="4" instance="1" label="Battery Report" max="1" min="0" size="1" type="list" units="" value="1">
+            <Help>
+                Default: Send once a day
+            </Help>
+            <Item label="Only send battery status as notification" value="0"/>
+            <Item label="Send once a day" value="1"/>
+        </Value>
+        <Value genre="config" index="5" instance="1" label="Temperature Report Threshold" max="50" min="0" type="byte" units="0.1°C" value="5">
+            <Help>
+                0: Don't send temperature automatically.
+                1-50: Report temperature at 0.1-5.0°C temperature difference.
+                Default: 5 (Delta = 0.5°C)
+            </Help>
+        </Value>
+        <Value genre="config" index="6" instance="1" label="Valve Opening Percentage Report" max="100" min="0" type="byte" units="" value="0">
+            <Help>
+                0: Don't send Valve opening percentage automatically.
+                1-100: Report valve opening percentage at a delta of 1-100%.
+                Default: 0
+            </Help>
+        </Value>
+        <Value genre="config" index="7" instance="1" label="Open Window Detection" max="3" min="0" size="1" type="list" units="" value="2">
+            <Help>
+                Default: Medium sensibility
+            </Help>
+            <Item label="Disabled" value="0"/>
+            <Item label="Low sensibility" value="1"/>
+            <Item label="Medium sensibility" value="2"/>
+            <Item label="High sensibility" value="3"/>
+        </Value>
+        <Value genre="config" index="8" instance="1" label="Measured Temperature Offset" max="255" min="0" type="byte" units="" value="0">
+            <Help>
+                206-255: -5.0 to -0.1°C.
+                0-50: 0°C-5°C.
+                128: External Temperature Sensor.
+                Default: 0 (0.0°C Offset)
+            </Help>
+        </Value>
+    </CommandClass>
+</Product>
+

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -230,6 +230,7 @@
 		<Product type="0002" id="0007" name="ZWA008 Door Window Sensor 7" config="aeotec/zwa008.xml"/>
 		<Product type="0102" id="0007" name="ZWA008 Door Window Sensor 7" config="aeotec/zwa008.xml"/>
 		<Product type="0202" id="0007" name="ZWA008 Door Window Sensor 7" config="aeotec/zwa008.xml"/>
+		<Product type="0002" id="0015" name="ZWA021 Thermostatic Valve" config="aeotec/zwa021.xml"/>
 	</Manufacturer>
 	<Manufacturer id="0088" name="Airvent SAM S.p.A.">
 	</Manufacturer>


### PR DESCRIPTION
Added support for the Aeotec Radiator Thermostat zwa021 (https://aeotec.com/z-wave-home-automation/thermostat-radiator-valve-trv/)

The config file was copied from https://github.com/OpenZWave/open-zwave/blob/master/config/aeotec/zwa021.xml

PS: It looks like that the zwa021 is basically the same as the eurotronic spirit (see config/eur_spiritz.xml)

Tested with HA: 0.104.2 / HassOS 3.8